### PR TITLE
feat: Configure codejail and run safety check at startup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 **********
 
+0.4.0 - 2025-02-11
+******************
+Changed
+=======
+* Codejail is now properly configured at startup
+* Service will refuse to execute code if basic smoke tests fail at startup. Also, healthcheck endpoint will remain unhealthy.
+
 0.3.0 - 2025-01-30
 ******************
 

--- a/codejail_service/__init__.py
+++ b/codejail_service/__init__.py
@@ -1,4 +1,4 @@
 """
 codejail-service module.
 """
-__version__ = '0.3.0'
+__version__ = '0.4.0'

--- a/codejail_service/apps/api/apps.py
+++ b/codejail_service/apps/api/apps.py
@@ -1,0 +1,31 @@
+"""
+Config for main API.
+"""
+
+import logging
+
+from codejail.django_integration_utils import apply_django_settings
+from django.apps import AppConfig
+from django.conf import settings
+
+from codejail_service.startup_check import run_startup_safety_check
+
+log = logging.getLogger(__name__)
+
+
+class CodejailApiConfig(AppConfig):
+    """
+    AppConfig for API views.
+
+    The only reason we need this to be an app is so that we can hook into the
+    ready() callback at startup. Any other mechanism would be fine too.
+    """
+    name = "codejail_service.apps.api"
+
+    def ready(self):
+        # Codejail needs this at startup
+        apply_django_settings(settings.CODE_JAIL)
+
+        # Perform self-check and initialize status for healthcheck and
+        # code-exec views to consult.
+        run_startup_safety_check()

--- a/codejail_service/apps/core/tests/test_views.py
+++ b/codejail_service/apps/core/tests/test_views.py
@@ -1,15 +1,36 @@
 """Test core.views."""
 
+from unittest.mock import patch
+
+import ddt
 from django.test import TestCase
 from django.urls import reverse
 
 
+@ddt.ddt
 class HealthTests(TestCase):
     """Tests of the health endpoint."""
 
-    def test_healthcheck(self):
-        """Test that the endpoint reports when all services are healthy."""
-        response = self.client.get(reverse('health'))
+    @ddt.data(False, None, "garbage")
+    def test_unhealthy(self, safety_state):
+        """Test that the endpoint reports error when safety checks failed or haven't run."""
+        with patch('codejail_service.startup_check.STARTUP_SAFETY_CHECK_OK', safety_state):
+            response = self.client.get(reverse('health'))
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response['content-type'], 'application/json')
+
+        expected_data = {
+            'status': 'UNAVAILABLE'
+        }
+
+        self.assertJSONEqual(response.content, expected_data)
+
+    def test_healthy(self):
+        """Test that the endpoint reports OK when all services are healthy."""
+        with patch('codejail_service.startup_check.STARTUP_SAFETY_CHECK_OK', True):
+            response = self.client.get(reverse('health'))
+
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['content-type'], 'application/json')
 

--- a/codejail_service/apps/core/views.py
+++ b/codejail_service/apps/core/views.py
@@ -4,28 +4,24 @@ import logging
 from django.http import JsonResponse
 from edx_django_utils.monitoring import ignore_transaction
 
+from codejail_service.startup_check import is_exec_safe
+
 logger = logging.getLogger(__name__)
 
 
-def health(_):
-    """Allows a load balancer to verify this service is up.
-
-    Checks the status of the database connection on which this service relies.
+def health(_request):
+    """
+    Allows a load balancer to verify this service is up and healthy.
 
     Returns:
-        HttpResponse: 200 if the service is available, with JSON data indicating the health of each required service
-        HttpResponse: 503 if the service is unavailable, with JSON data indicating the health of each required service
-
-    Example:
-        >>> response = requests.get('https://codejail-service.edx.org/health')
-        >>> response.status_code
-        200
-        >>> response.content
-        '{"overall_status": "OK", "detailed_status": {"database_status": "OK", "lms_status": "OK"}}'
+        HttpResponse: 200 if the service is available
+        HttpResponse: 503 if the service is unavailable
     """
 
     # Ignores health check in performance monitoring so as to not artifically inflate our response time metrics
     ignore_transaction()
 
-    # Always "healthy", for now -- no state to look at. Revisit later.
-    return JsonResponse({'status': 'OK'})
+    if is_exec_safe():
+        return JsonResponse({'status': 'OK'}, status=200)
+    else:
+        return JsonResponse({'status': 'UNAVAILABLE'}, status=503)

--- a/codejail_service/codejail.py
+++ b/codejail_service/codejail.py
@@ -1,0 +1,28 @@
+"""
+Wrappers and utilities for codejail library.
+"""
+
+from copy import deepcopy
+
+
+def safe_exec(code, input_globals, **kwargs):
+    """
+    Call safe_exec and work around several of its problems.
+
+    Returns new globals dictionary that results from execution.
+    (Does not mutate input.)
+    """
+    # This needs to be a lazy import because as soon as codejail's
+    # safe_exec module loads, it immediately makes a decision about
+    # whether to run in always-unsafe mode.
+    #
+    # See https://github.com/openedx/codejail/issues/225 for maybe
+    # fixing this.
+
+    # pylint: disable=import-outside-toplevel
+    from codejail.safe_exec import safe_exec as real_safe_exec
+
+    # Prevent mutation of input
+    output_globals = deepcopy(input_globals)
+    real_safe_exec(code, output_globals, **kwargs)
+    return output_globals

--- a/codejail_service/settings/test.py
+++ b/codejail_service/settings/test.py
@@ -1,3 +1,7 @@
 """Settings for use during testing."""
 
 from codejail_service.settings.base import *  # pylint: disable=wildcard-import
+
+# We don't have any meaningful settings to add here for unit tests,
+# but codejail will still want the dictionary to exist.
+CODE_JAIL = {}

--- a/codejail_service/startup_check.py
+++ b/codejail_service/startup_check.py
@@ -1,0 +1,124 @@
+"""
+State and accessors for a safety check that is run at startup.
+"""
+
+import logging
+
+from codejail_service.codejail import safe_exec
+
+log = logging.getLogger(__name__)
+
+# Results of the safety check that was performed at startup.
+#
+# Expected values:
+#
+# - None: The check has not yet been performed
+# - True: No issues were detected
+# - False: A fundamental safety or function issue was detected
+#
+# Any other value indicates that the safety check failed in an
+# unexpected way, perhaps raising an exception.
+#
+# The *only value* that indicates that it is safe to receive code-exec
+# calls is `True`.
+STARTUP_SAFETY_CHECK_OK = None
+
+
+def is_exec_safe():
+    """
+    Return True if and only if it is safe to accept code-exec calls.
+    """
+    return STARTUP_SAFETY_CHECK_OK is True
+
+
+def run_startup_safety_check():
+    """
+    Perform a sandboxing safety check.
+
+    Determines if the service is running with an acceptable configuration.
+    This is *not* a full test suite, just a basic check that codejail
+    is actually configured in sandboxing mode.
+
+    This just initializes state. Afterwards, is_exec_safe can be called.
+    """
+    global STARTUP_SAFETY_CHECK_OK
+
+    # App initialization can happen multiple times; just run checks once.
+    if STARTUP_SAFETY_CHECK_OK is not None:
+        return
+
+    tests = [
+        {
+            "name": "Basic code execution",
+            "fn": _test_basic_function,
+        },
+        {
+            "name": "Block sandbox escape by disk access",
+            "fn": _test_escape_disk,
+        },
+        {
+            "name": "Block sandbox escape by child process",
+            "fn": _test_escape_subprocess,
+        },
+    ]
+
+    any_failed = False
+    for test in tests:
+        try:
+            result = test['fn']()
+        except BaseException as e:
+            result = f"Uncaught exception from test: {e!r}"
+
+        if result is True:
+            log.info(f"Startup test {test['name']!r} passed")
+        else:
+            any_failed = True
+            log.error(f"Startup test {test['name']!r} failed with: {result!r}")
+
+    STARTUP_SAFETY_CHECK_OK = not any_failed
+
+
+def _test_basic_function():
+    """
+    Test for basic code execution (math).
+    """
+    globals_out = safe_exec("x = x + 1", {'x': 16})
+
+    if 'x' not in globals_out:
+        return "x not in returned globals"
+    if globals_out['x'] != 17:
+        return f"returned global x != 17 (was {globals_out['x']})"
+
+    return True
+
+
+def _test_escape_disk():
+    """
+    Test for sandbox escape by reading from files outside of sandbox.
+    """
+    try:
+        globals_out = safe_exec("import os; ret = os.listdir('/')", {})
+        return f"Expected error, but code ran successfully. Globals: {globals_out!r}"
+    except BaseException as e:
+        if "Permission denied" in repr(e):
+            return True
+        else:
+            return f"Expected permission error, but got: {e!r}"
+
+
+def _test_escape_subprocess():
+    """
+    Test for sandbox escape by creating a child process.
+    """
+    try:
+        globals_out = safe_exec(
+            "import subprocess;"
+            "ret = subprocess.check_output('echo $((6 * 7))', shell=True)",
+            {},
+        )
+        return f"Expected error, but code ran successfully. Globals: {globals_out!r}"
+    except BaseException as e:
+        if "Permission denied" in repr(e):
+            return True
+        else:
+            return f"Expected permission error, but got: {e!r}"

--- a/codejail_service/tests/test_startup_check.py
+++ b/codejail_service/tests/test_startup_check.py
@@ -1,0 +1,144 @@
+"""
+Tests for startup safety and function check.
+"""
+
+from unittest.mock import call, patch
+
+import ddt
+from django.test import TestCase
+
+from codejail_service import startup_check
+from codejail_service.startup_check import is_exec_safe, run_startup_safety_check
+
+
+class TestStateCheck(TestCase):
+
+    @patch('codejail_service.startup_check.STARTUP_SAFETY_CHECK_OK', None)
+    def test_baseline(self):
+        assert is_exec_safe() is False
+
+    @patch('codejail_service.startup_check.STARTUP_SAFETY_CHECK_OK', "hello")
+    def test_weird_value(self):
+        assert is_exec_safe() is False
+
+    @patch('codejail_service.startup_check.STARTUP_SAFETY_CHECK_OK', True)
+    def test_healthy(self):
+        assert is_exec_safe() is True
+
+
+DEFAULT = object()
+
+
+def responses(math=DEFAULT, disk=DEFAULT, child=DEFAULT):
+    """
+    Return a list of the expected safe_exec responses, with optional overrides.
+
+    This is intended to be used in mocking out safe_exec in the exact
+    sequence of calls that the startup safety check function
+    makes. Each value in the list should either be a return value of
+    safe_exec or an Exception instance. (Anything that is compatible with
+    the behavior of the side_effect param in unittest.mock.)
+
+    The default list of responses will satisfy the startup checks and
+    should result in a "we're healthy" state. The math/disk/child kwargs
+    can be overridden with alternative responses to those individual
+    checks (`_test_basic_function` etc.) in order to test whether those
+    responses provoke an "unhealthy" determination.
+    """
+    if math is DEFAULT:
+        math = {'x': 17}
+    if disk is DEFAULT:
+        disk = Exception("... Permission denied ...")
+    if child is DEFAULT:
+        child = Exception("... Permission denied ...")
+
+    return [math, disk, child]
+
+
+@ddt.ddt
+class TestInit(TestCase):
+
+    @patch('codejail_service.startup_check.STARTUP_SAFETY_CHECK_OK', None)
+    def test_unsafe_tests_default(self):
+        """
+        The test environment is unconfined, so the safety checks should fail.
+        """
+        run_startup_safety_check()
+        assert startup_check.STARTUP_SAFETY_CHECK_OK is False
+
+    @ddt.data(
+        # Baseline mocked values: Everything passes.
+        (responses(), True),
+        # Extraneous globals don't cause a check failure
+        (responses(math={'x': 17, 'unrelated': 'ignored'}), True),
+
+        # Wrong exception message
+        (responses(disk=Exception("... Module not found ...")), False),
+        (responses(child=Exception("... Module not found ...")), False),
+        # Lack of an exception
+        (responses(disk={}), False),
+        (responses(child={}), False),
+        # Wrong value for global
+        (responses(math={'x': 999}), False),
+        # Missing global
+        (responses(math={'y': 17}), False),
+        # Exception when expecting a value
+        (responses(math=Exception("Divide by zero")), False),
+    )
+    @ddt.unpack
+    @patch('codejail_service.startup_check.STARTUP_SAFETY_CHECK_OK', None)
+    def test_success_and_failure_modes(self, safe_exec_responses, expected_status):
+        """
+        Test various unexpected safe_exec responses, via mocking.
+        """
+        with patch(
+                'codejail_service.startup_check.safe_exec',
+                side_effect=safe_exec_responses,
+        ) as mock_safe_exec:
+            run_startup_safety_check()
+        assert startup_check.STARTUP_SAFETY_CHECK_OK is expected_status
+        assert mock_safe_exec.call_count == 3
+
+    @patch('codejail_service.startup_check.STARTUP_SAFETY_CHECK_OK', None)
+    def test_logging(self):
+        """
+        Check that we get useful log messages.
+
+        This relies on safe_exec actually getting called, but in
+        unsafe mode (because unit tests don't run under confinement.)
+        """
+        with (
+                patch('codejail_service.startup_check.log.info') as mock_log_info,
+                patch('codejail_service.startup_check.log.error') as mock_log_error,
+        ):
+            run_startup_safety_check()
+
+        assert startup_check.STARTUP_SAFETY_CHECK_OK is False
+
+        assert mock_log_info.call_args_list == [
+            call("Startup test 'Basic code execution' passed"),
+        ]
+
+        assert len(mock_log_error.call_args_list) == 2
+        assert (
+            "Startup test 'Block sandbox escape by disk access' failed with: "
+            "\"Expected error, but code ran successfully. Globals: {'ret': ['"
+        ) in mock_log_error.call_args_list[0][0][0]
+        assert (
+            "Startup test 'Block sandbox escape by child process' failed with: "
+            r'''"Expected error, but code ran successfully. Globals: {'ret': '42\\n'}"'''
+        ) == mock_log_error.call_args_list[1][0][0]
+
+    @ddt.data(True, False)
+    def test_skip_reinit(self, starting_state):
+        """
+        If startup check has already run, don't run it again.
+        """
+        with (
+                patch('codejail_service.startup_check.STARTUP_SAFETY_CHECK_OK', starting_state),
+                patch('codejail_service.startup_check.safe_exec') as mock_safe_exec,
+        ):
+            run_startup_safety_check()
+            assert startup_check.STARTUP_SAFETY_CHECK_OK is starting_state
+
+        mock_safe_exec.assert_not_called()


### PR DESCRIPTION
- Initialize codejail at startup
- Run safety checks at startup, locking out the API if the checks fail

If codejail isn't properly configured, it defaults to running code unsafely. To prevent this from affecting the service, we run a smoke test at startup to check if there's anything just *drastically* wrong.

If this check does not pass, two things happen:

- The healthcheck endpoint will never return a 200 OK
- The code-exec endpoint will refuse with a 500 error

Supporting changes:

- Define an explicit AppConfig for the api subpackage so that we can hook into the `ready()` mechanism
- Wrap `safe_exec` to prevent codejail eagerly setting `UNSAFE=True` at module load time. (Not clear why this doesn't affect edx-platform; maybe something to do with app vs. middleware load order.) Filed https://github.com/openedx/codejail/issues/225 for possibly fixing this.
- `safe_exec` wrapper also performs a deepcopy to allow callers to reason about the globals dict more easily.

Other changes:

- Clean up healthcheck docstring (mostly just trim it down)
- Lint cleanup

Part of https://github.com/edx/edx-arch-experiments/issues/927

----

Manual testing performed with changes to the Dockerfile and to devstack (PRs pending), and mostly entailed calling the healthcheck endpoint.

When passing, the startup logs look like this:

```
edx.devstack.codejail  | 2025-02-05 23:26:03,745 INFO 365 [codejail_service.startup_check] [user None] [ip None] startup_check.py:73 - Startup test 'Basic code execution' passed
edx.devstack.codejail  | 2025-02-05 23:26:03,819 INFO 365 [codejail_service.startup_check] [user None] [ip None] startup_check.py:73 - Startup test 'Block sandbox escape by disk access' passed
edx.devstack.codejail  | 2025-02-05 23:26:03,892 INFO 365 [codejail_service.startup_check] [user None] [ip None] startup_check.py:73 - Startup test 'Block sandbox escape by child process' passed
```

When codejail is misconfigured:

```
edx.devstack.codejail  | 2025-02-06 11:47:41,056 WARNING 419 [codejail] [user None] [ip None] safe_exec.py:305 - Using codejail/safe_exec.py:not_safe_exec for None
edx.devstack.codejail  | 2025-02-06 11:47:41,058 INFO 419 [codejail_service.startup_check] [user None] [ip None] startup_check.py:73 - Startup test 'Basic code execution' passed
edx.devstack.codejail  | 2025-02-06 11:47:41,058 WARNING 419 [codejail] [user None] [ip None] safe_exec.py:305 - Using codejail/safe_exec.py:not_safe_exec for None
edx.devstack.codejail  | 2025-02-06 11:47:41,059 ERROR 419 [codejail_service.startup_check] [user None] [ip None] startup_check.py:76 - Startup test 'Block sandbox escape by disk access' failed with: "Expected error, but code ran successfully. Globals: {'ret': ['var', 'home', 'lib64', 'tmp', 'boot', 'media', 'root', 'etc', 'srv', 'proc', 'usr', 'run', 'bin', 'dev', 'opt', 'lib', 'sbin', 'mnt', 'sys', 'edx', '.dockerenv', 'app', 'venv', 'sandbox', 'lib.usr-is-merged']}"
edx.devstack.codejail  | 2025-02-06 11:47:41,059 WARNING 419 [codejail] [user None] [ip None] safe_exec.py:305 - Using codejail/safe_exec.py:not_safe_exec for None
edx.devstack.codejail  | 2025-02-06 11:47:41,061 ERROR 419 [codejail_service.startup_check] [user None] [ip None] startup_check.py:76 - Startup test 'Block sandbox escape by child process' failed with: "Expected error, but code ran successfully. Globals: {'ret': '42\\n'}"
```

----

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

