### PR TITLE
fix: Return globals even when an error was raised

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+0.4.1 - 2025-02-18
+******************
+Fixed
+=====
+* Return ``globals_dict`` even when also returning an ``emsg`` error
+
 0.4.0 - 2025-02-11
 ******************
 Changed

--- a/codejail_service/__init__.py
+++ b/codejail_service/__init__.py
@@ -1,4 +1,4 @@
 """
 codejail-service module.
 """
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/codejail_service/apps/api/v0/tests/test_views.py
+++ b/codejail_service/apps/api/v0/tests/test_views.py
@@ -129,5 +129,9 @@ class TestExecService(TestCase):
         """Report exceptions from jailed code."""
         self._test_codejail_api(
             params={'code': '1/0', 'globals_dict': {}},
-            exp_status=200, exp_body={'emsg': 'ZeroDivisionError: division by zero'},
+            exp_status=200,
+            exp_body={
+                'globals_dict': {},
+                'emsg': 'ZeroDivisionError: division by zero',
+            },
         )

--- a/codejail_service/codejail.py
+++ b/codejail_service/codejail.py
@@ -9,14 +9,23 @@ def safe_exec(code, input_globals, **kwargs):
     """
     Call safe_exec and work around several of its problems.
 
-    Returns new globals dictionary that results from execution.
-    (Does not mutate input.)
+    input_globals is not mutated, unlike in the codejail library.
+
+    Returns a tuple of (globals dict, error message).
+
+    - globals dict: The globals dictionary that resulted from execution,
+      whether or not an error was raised
+    - error message: An error message string, or None if execution succeeded
+
+    This approach allows us to return the new globals dictionary even if
+    an error is raised, without requiring us to mutate the input. (And this
+    approach is much better for unit testing than the mutation option is.)
     """
     # This needs to be a lazy import because as soon as codejail's
     # safe_exec module loads, it immediately makes a decision about
     # whether to run in always-unsafe mode.
     #
-    # See https://github.com/openedx/codejail/issues/225 for maybe
+    # See https://github.com/openedx/codejail/issues/16 for maybe
     # fixing this.
 
     # pylint: disable=import-outside-toplevel
@@ -24,5 +33,8 @@ def safe_exec(code, input_globals, **kwargs):
 
     # Prevent mutation of input
     output_globals = deepcopy(input_globals)
-    real_safe_exec(code, output_globals, **kwargs)
-    return output_globals
+    try:
+        real_safe_exec(code, output_globals, **kwargs)
+        return (output_globals, None)
+    except BaseException as e:
+        return (output_globals, str(e))

--- a/codejail_service/startup_check.py
+++ b/codejail_service/startup_check.py
@@ -47,40 +47,40 @@ def run_startup_safety_check():
     if STARTUP_SAFETY_CHECK_OK is not None:
         return
 
-    tests = [
+    checks = [
         {
             "name": "Basic code execution",
-            "fn": _test_basic_function,
+            "fn": _check_basic_function,
         },
         {
             "name": "Block sandbox escape by disk access",
-            "fn": _test_escape_disk,
+            "fn": _check_escape_disk,
         },
         {
             "name": "Block sandbox escape by child process",
-            "fn": _test_escape_subprocess,
+            "fn": _check_escape_subprocess,
         },
     ]
 
     any_failed = False
-    for test in tests:
+    for check in checks:
         try:
-            result = test['fn']()
+            result = check['fn']()
         except BaseException as e:
-            result = f"Uncaught exception from test: {e!r}"
+            result = f"Uncaught exception from check: {e!r}"
 
         if result is True:
-            log.info(f"Startup test {test['name']!r} passed")
+            log.info(f"Startup check {check['name']!r} passed")
         else:
             any_failed = True
-            log.error(f"Startup test {test['name']!r} failed with: {result!r}")
+            log.error(f"Startup check {check['name']!r} failed with: {result!r}")
 
     STARTUP_SAFETY_CHECK_OK = not any_failed
 
 
-def _test_basic_function():
+def _check_basic_function():
     """
-    Test for basic code execution (math).
+    Check for basic code execution (math).
     """
     (globals_out, error_message) = safe_exec("x = x + 1", {'x': 16})
 
@@ -94,9 +94,9 @@ def _test_basic_function():
     return True
 
 
-def _test_escape_disk():
+def _check_escape_disk():
     """
-    Test for sandbox escape by reading from files outside of sandbox.
+    Check for sandbox escape by reading from files outside of sandbox.
     """
     (globals_out, error_message) = safe_exec("import os; ret = os.listdir('/')", {})
 
@@ -108,9 +108,9 @@ def _test_escape_disk():
     return True
 
 
-def _test_escape_subprocess():
+def _check_escape_subprocess():
     """
-    Test for sandbox escape by creating a child process.
+    Check for sandbox escape by creating a child process.
     """
     (globals_out, error_message) = safe_exec(
         "import subprocess;"

--- a/codejail_service/startup_check.py
+++ b/codejail_service/startup_check.py
@@ -82,8 +82,10 @@ def _test_basic_function():
     """
     Test for basic code execution (math).
     """
-    globals_out = safe_exec("x = x + 1", {'x': 16})
+    (globals_out, error_message) = safe_exec("x = x + 1", {'x': 16})
 
+    if error_message is not None:
+        return f"Unexpected error: {error_message}"
     if 'x' not in globals_out:
         return "x not in returned globals"
     if globals_out['x'] != 17:
@@ -96,29 +98,29 @@ def _test_escape_disk():
     """
     Test for sandbox escape by reading from files outside of sandbox.
     """
-    try:
-        globals_out = safe_exec("import os; ret = os.listdir('/')", {})
+    (globals_out, error_message) = safe_exec("import os; ret = os.listdir('/')", {})
+
+    if error_message is None:
         return f"Expected error, but code ran successfully. Globals: {globals_out!r}"
-    except BaseException as e:
-        if "Permission denied" in repr(e):
-            return True
-        else:
-            return f"Expected permission error, but got: {e!r}"
+    if "Permission denied" not in error_message:
+        return f"Expected permission error, but got: {error_message}"
+
+    return True
 
 
 def _test_escape_subprocess():
     """
     Test for sandbox escape by creating a child process.
     """
-    try:
-        globals_out = safe_exec(
-            "import subprocess;"
-            "ret = subprocess.check_output('echo $((6 * 7))', shell=True)",
-            {},
-        )
+    (globals_out, error_message) = safe_exec(
+        "import subprocess;"
+        "ret = subprocess.check_output('echo $((6 * 7))', shell=True)",
+        {},
+    )
+
+    if error_message is None:
         return f"Expected error, but code ran successfully. Globals: {globals_out!r}"
-    except BaseException as e:
-        if "Permission denied" in repr(e):
-            return True
-        else:
-            return f"Expected permission error, but got: {e!r}"
+    if "Permission denied" not in error_message:
+        return f"Expected permission error, but got: {error_message}"
+
+    return True

--- a/codejail_service/tests/test_startup_check.py
+++ b/codejail_service/tests/test_startup_check.py
@@ -42,7 +42,7 @@ def responses(math=DEFAULT, disk=DEFAULT, child=DEFAULT):
     The default list of responses will satisfy the startup checks and
     should result in a "we're healthy" state. The math/disk/child kwargs
     can be overridden with alternative responses to those individual
-    checks (`_test_basic_function` etc.) in order to test whether those
+    checks (`_check_basic_function` etc.) in order to test whether those
     responses provoke an "unhealthy" determination.
     """
     if math is DEFAULT:
@@ -80,7 +80,7 @@ class TestInit(TestCase):
 
         # Confirm log message for at least one of the checks
         assert mock_log_error.call_args_list[0] == call(
-            '''Startup test 'Basic code execution' failed with: "Uncaught exception from test: Exception('oops')"'''
+            '''Startup check 'Basic code execution' failed with: "Uncaught exception from check: Exception('oops')"'''
         )
 
     @ddt.data(
@@ -133,16 +133,16 @@ class TestInit(TestCase):
         assert startup_check.STARTUP_SAFETY_CHECK_OK is False
 
         assert mock_log_info.call_args_list == [
-            call("Startup test 'Basic code execution' passed"),
+            call("Startup check 'Basic code execution' passed"),
         ]
 
         assert len(mock_log_error.call_args_list) == 2
         assert (
-            "Startup test 'Block sandbox escape by disk access' failed with: "
+            "Startup check 'Block sandbox escape by disk access' failed with: "
             "\"Expected error, but code ran successfully. Globals: {'ret': ['"
         ) in mock_log_error.call_args_list[0][0][0]
         assert (
-            "Startup test 'Block sandbox escape by child process' failed with: "
+            "Startup check 'Block sandbox escape by child process' failed with: "
             r'''"Expected error, but code ran successfully. Globals: {'ret': '42\\n'}"'''
         ) == mock_log_error.call_args_list[1][0][0]
 


### PR DESCRIPTION
edxapp expects to read `globals_dict` from the response even when an error has been caught and signaled with `emsg`. This commit fixes the API response to match this expectation.

This can't be done without some changes to how we call safe_exec, since we need to capture both changes to the globals *and* a possible exception. With the current approach, we can only get one or the other. So to make this work, we have to take one of two approaches:

- A. Stop doing the defensive deepcopy on globals, making the safe_exec wrapper a much thinner wrapper than before. The relying code (code-exec API and startup checks) would pass in a mutable globals dict and no longer expect a return value. When an exception occurs, the mutated globals dict would still be available to read.
- B. Keep the deepcopy, but move exception-catching into the safe_exec wrapper. Return a pair of globals dict and exception (or None). This more closely mirrors the actual API we expose in the service. Relying code has to destructure the tuple rather than using an except block.

I actually tried approach A at first, but discovered that unit testing became *far* more unpleasant -- we would have to make a function that behaves differently each time it's called, but we wouldn't be able to use the built-in behavior of unittest.mock's side_effects, because it can only help with return values. And safe_exec would no longer be in the business of returning things.

With approach B, the mock responses become tuples, which is a little bit less magic, as we're no longer relying on side_effects' special handling of exception objects.

Also, update issue link in safe_exec docstring to an older ticket. The newer one has been closed as a dup.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
