### PR TITLE
Add API test suite and make a couple of fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+0.4.2 - 2025-03-03
+******************
+Fixed
+=====
+* Add proper error handling to code-exec endpoint when ``payload`` param is missing or malformed
+
 0.4.1 - 2025-02-18
 ******************
 Fixed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Unreleased
 Fixed
 =====
 * Add proper error handling to code-exec endpoint when ``payload`` param is missing or malformed
+* Log unexpected exceptions instead of returning them as an ``emsg``
 
 0.4.1 - 2025-02-18
 ******************

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,8 @@ This is intended to be run as a fully internal service with no database or admin
 
 While the service uses AppArmor as a first (and really, only) line of defense, it should also be deployed in a way that does not allow direct connections to other IDAs or internal services within the Open edX deployment. In the ideal situation, networking would be set up to only allow outbound connections to a predetermined set of IPs or domains.
 
+After any significant change to security settings, consider running the tests in ``./api_tests/``. These are run manually against a deployed service and can check for various sandbox weaknesses.
+
 Getting Started with Development
 ********************************
 

--- a/api_tests/README.rst
+++ b/api_tests/README.rst
@@ -1,0 +1,36 @@
+API tests
+#########
+
+Functional and safety tests against the API of a running instance.
+
+These are not unit tests, and are not run automatically as part of any Open edX CI workflow. The intention is for these to be run manually against a deployment as a regression test after any significant changes to the security infrastructure (e.g. the AppArmor profile, sandboxing layout, etc.)
+
+These require the instance to be configured with AppArmor and sandboxing fully in effect. Tests must be run with environment variable ``API_TEST_SERVICE_BASE`` set to the base URL of the instance.
+
+Example run, assuming a properly configured codejail-service is running on a local port::
+
+  # activate Python 3.12 virtualenv, and then:
+  make requirements
+  export API_TEST_SERVICE_BASE=http://localhost:18030
+  pytest --no-cov ./api_tests/
+
+Test names and sabotage testing
+*******************************
+
+Tests are named according to the following:
+
+* ``test_deny_*`` to show that sandboxing forbids an action
+* ``test_allow_*`` to show that an action is permitted by sandboxing, indicating a contrast to a deny action (e.g. writing to certain file paths is allowed, even though others are denied)
+* ``test_support_*`` to exercise features of the API or the code execution environment that aren't related to sandboxing
+
+This allows for a type of "sabotage testing": If the sandboxing mechanism is disabled and the codejail-service altered to allow code execution anyway, we should expect the ``test_deny_*`` tests to start failing and the remaining tests to continue passing. This can be done manually in a local development environment to ensure that all of the tests are written properly. This could catch a poorly written deny test that is expecting the wrong error, or isn't specific enough. For example, a syntax error could cause a deny even though the action would be allowed if the syntax error were repaired.
+
+To perform this sabotage testing in a development environment:
+
+1. Set ``STARTUP_SAFETY_CHECK_OK = True`` in ``startup_checks.py``
+2. Remove the apparmor confinement (e.g. remove ``security_opt`` if using Docker Compose)
+3. Run pytest with ``-v`` so that individual tests are always reported, and pipe the results into ``grep -P '(test_deny.*PASSED|test_(allow|support)_.*FAILED)|py::test_(?!deny|allow|support)'`` to find:
+
+   * denial tests that are still passing (which should not happen, and likely indicates a badly written test)
+   * allow/support tests that are now failing for some reason (which would be strange, and should be investigated)
+   * tests that do not follow the naming scheme

--- a/api_tests/__init__.py
+++ b/api_tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Base package of API tests.
+"""

--- a/api_tests/test_filesystem.py
+++ b/api_tests/test_filesystem.py
@@ -1,0 +1,120 @@
+"""
+Tests of filesystem access, allowed and denied.
+
+Mostly should be denied, but parts of sandbox should be allowed.
+"""
+
+from textwrap import dedent
+from unittest import TestCase
+
+import ddt
+
+from api_tests.utils import call_api_code_error, call_api_success
+
+
+def test_allow_list_in_own_sandbox():
+    """
+    We can list files in our own sandbox.
+    """
+    code = "import os; out = os.listdir('.')"
+    listing = call_api_success(code, {})["out"]
+    # A few things we should expect the codejail library to have created:
+    assert "tmp" in listing
+    assert "jailed_code" in listing
+
+
+def test_allow_write_in_own_sandbox():
+    """
+    We can create files in our own sandbox.
+    """
+    code = dedent("""
+      with open("tmp/api-test.txt", 'w') as f:
+          f.write("sample")
+
+      with open("tmp/api-test.txt", 'r') as f:
+          out = f.read()
+    """)
+    assert {"out": "sample"} == call_api_success(code, {})
+
+
+@ddt.ddt
+class TestFilesystemDenial(TestCase):
+    """
+    Various wider-OS filesystem operations denied to us.
+    """
+
+    @ddt.data(
+        # Some file that's fairly harmless and that wouldn't have been
+        # *specifically* blocked.
+        "/etc/hosts",
+        # Another quasi-harmless area of the filesystem
+        "/proc/1/cmdline",
+    )
+    def test_deny_read_os_files(self, file_path):
+        """
+        We can't read most files out in the broader OS.
+        """
+        code = dedent(f"""
+          with open({file_path!r}, 'r') as f:
+              f.read()
+        """)
+        (_, emsg) = call_api_code_error(code, {})
+        assert f"PermissionError: [Errno 13] Permission denied: \\'{file_path}\\'" in emsg
+
+    @ddt.data(
+        # Generic OS paths
+        "/sys",
+        "/",
+        "/tmp",
+        # Parent directory contains other users' codejails
+        "../",
+    )
+    def test_deny_list_os_dirs(self, dir_path):
+        """
+        We can't list various directories.
+        """
+        code = dedent(f"""
+          import os
+          out = os.listdir({dir_path!r})
+        """)
+        (_, emsg) = call_api_code_error(code, {})
+        assert f"PermissionError: [Errno 13] Permission denied: \\'{dir_path}\\'" in emsg
+
+    @ddt.data(
+        "/tmp/apitest.txt",
+        "../apitest.txt",
+    )
+    def test_deny_write_outside_sandbox(self, file_path):
+        """
+        We can't write to various places outside the sandbox.
+        """
+        code = dedent(f"""
+          with open({file_path!r}, 'w') as f:
+              f.write("test")
+        """)
+        (_, emsg) = call_api_code_error(code, {})
+        assert f"PermissionError: [Errno 13] Permission denied: \\'{file_path}\\'" in emsg
+
+
+def test_allow_python_path():
+    """
+    Everything that's added to sys.path by the safe_exec prefix code should be
+    listable or readable (if it exists).
+    """
+    code = dedent("""
+      import os, os.path, sys
+
+      out = ""
+      for p in sys.path:
+          if os.path.isdir(p):
+              result = len(os.listdir(p))
+          elif os.path.isfile(p):
+              with open(p, 'r') as f:
+                  result = f.read(1)
+          else:
+              result = "missing or other type"
+
+          out += f"{p}: {result!r}\\n"
+    """)
+    globals_out = call_api_success(code, {})
+    assert ": " in globals_out['out']

--- a/api_tests/test_functional.py
+++ b/api_tests/test_functional.py
@@ -1,0 +1,34 @@
+"""
+Tests of basic functionality (just running generic Python).
+"""
+
+from textwrap import dedent
+
+from api_tests.utils import call_api_success
+
+
+def test_support_globals_input_output():
+    """
+    We can use globals to pass inputs to the code and receive output.
+    """
+    assert {"input": 21, "out": 42} == call_api_success("out = input * 2", {"input": 21})
+
+
+def test_support_define_function():
+    """
+    We can run multi-line code and define functions.
+    """
+    code = dedent("""
+      def doubler(x):
+          return x * 2
+
+      out = doubler(input)
+    """)
+    assert {"input": 50, "out": 100} == call_api_success(code, {"input": 50})
+
+
+def test_support_selective_serialization():
+    """
+    Only serializable globals are returned; others are simply omitted.
+    """
+    assert {"out2": "hi"} == call_api_success("out1 = object(); out2 = 'hi'", {})

--- a/api_tests/test_network.py
+++ b/api_tests/test_network.py
@@ -1,0 +1,92 @@
+"""
+Tests of network access, all should be denied.
+
+This includes both high-level and low-level tests to ensure good coverage.
+"""
+
+from textwrap import dedent
+from unittest import TestCase
+
+import ddt
+
+from api_tests.utils import call_api_code_error, call_api_success
+
+
+def test_deny_make_http_call():
+    """
+    HTTP call involves both UDP and TCP outwards connections, so
+    it will fail even if only one of those is blocked. But it's a good
+    high-level test.
+    """
+    code = dedent("""
+      import urllib.request
+      urllib.request.urlopen('http://www.example.org/')
+    """)
+    (_, emsg) = call_api_code_error(code, {})
+    assert "urllib.error.URLError: <urlopen error [Errno -3] Temporary failure in name resolution>" in emsg
+
+
+def test_deny_resolve_dns():
+    """
+    No DNS lookups. This uses UDP.
+    """
+    code = "import socket; out = socket.gethostbyname('example.com')"
+    (_, emsg) = call_api_code_error(code, {})
+    assert "nsocket.gaierror: [Errno -2] Name or service not known" in emsg
+
+
+@ddt.ddt
+class TestSocketCreate(TestCase):
+    """
+    Tests on collections of socket configs. (Need class for ddt.)
+    """
+
+    @ddt.unpack
+    @ddt.data(
+        ('socket.AF_INET', 'socket.SOCK_STREAM'),
+        ('socket.AF_INET', 'socket.SOCK_DGRAM'),
+        ('socket.AF_INET6', 'socket.SOCK_STREAM'),
+        ('socket.AF_INET6', 'socket.SOCK_DGRAM'),
+        ('socket.AF_NETLINK', 'socket.SOCK_RAW'),
+    )
+    def test_deny_create_socket(self, address_family, socket_type):
+        """
+        Can't create a socket (even without calling bind or connect).
+        """
+        code = dedent(f"""
+          import socket
+          socket.socket({address_family}, {socket_type})
+        """)
+        (_, emsg) = call_api_code_error(code, {})
+        assert "PermissionError: [Errno 13] Permission denied" in emsg
+
+
+class TestUnixSocket(TestCase):
+    """
+    Unlike other socket types, Unix sockets are allowed (they're local files).
+
+    This isn't something we specifically support, but it's not problematic as long as
+    socket creation only happens within the sandbox.
+    """
+
+    def code_for_create_socket(self, path):
+        return dedent(f"""
+          import socket
+          s = socket.socket(socket.AF_UNIX, socket.SOCK_RAW)
+          s.bind("{path}.0.0")
+          # Just proving we have created some kind of socket
+          out = s.fileno()
+        """)
+
+    def test_allow_in_sandbox(self):
+        """Allowed when in own sandbox's tmp dir."""
+        code = self.code_for_create_socket("./tmp/test-socket")
+        globals_out = call_api_success(code, {})
+        # The actual value isn't strictly predictable
+        assert isinstance(globals_out['out'], int)
+
+    def test_deny_elsewhere(self):
+        """Denied when in OS tmp dir."""
+        code = self.code_for_create_socket("/tmp/test-socket")
+        (_, emsg) = call_api_code_error(code, {})
+        assert "PermissionError: [Errno 13] Permission denied" in emsg

--- a/api_tests/test_process.py
+++ b/api_tests/test_process.py
@@ -1,0 +1,30 @@
+"""
+Tests for process creation.
+"""
+
+from textwrap import dedent
+
+from api_tests.utils import call_api_code_error
+
+
+def test_deny_fork():
+    """
+    Can't fork own process excessively.
+    """
+    (_, emsg) = call_api_code_error(dedent("""
+      import os, sys
+
+      # codejail defaults NPROC to 15; pick something much higher
+      for _ in range(100):
+          pid = os.fork()
+
+          # If we're the child, die right away, otherwise the code suffix
+          # added by safe_exec to bundle up globals into a JSON response
+          # on stdout will run on *both* processes. Since they share a stdout,
+          # this would create garbled JSON and a JsonDecodeError rather than
+          # the more useful SafeExecException.
+          if pid == 0:
+              sys.exit(0)
+    """), {})
+    # 11 = EAGAIN: Resource temporarily unavailable (process limit, in this case)
+    assert "BlockingIOError: [Errno 11] Resource temporarily unavailable" in emsg

--- a/api_tests/test_sandbox_deps.py
+++ b/api_tests/test_sandbox_deps.py
@@ -1,0 +1,38 @@
+"""
+Tests of availability of sandbox dependencies.
+"""
+
+from textwrap import dedent
+
+from api_tests.utils import call_api_success
+
+
+def test_support_basic_import():
+    """
+    We can load *any* part of *any* expected library.
+
+    We use a library here that is unlikely to be in a generic virtualenv (such as
+    the app's own virtualenv) but that also doesn't have complicated dependencies
+    (especially C extensions, such as in numpy).
+    """
+    code = dedent("""
+      import networkx
+      out = networkx.__version__
+    """)
+    assert "out" in call_api_success(code, {})
+
+
+def test_support_numpy():
+    """
+    We can use numpy arrays.
+
+    numpy requires C extensions and is also a standard package to include
+    in codejail.
+    """
+    code = dedent("""
+      import numpy as np
+      a = np.array([1, 2, 3, 4, 5])
+      a = a * 2
+      out = int(a[-1])
+    """)
+    assert {"out": 10} == call_api_success(code, {})

--- a/api_tests/test_timeout.py
+++ b/api_tests/test_timeout.py
@@ -1,0 +1,63 @@
+"""
+Tests for execution time limits.
+"""
+
+import time
+from textwrap import dedent
+
+from api_tests.utils import call_api_code_error
+
+# An unreasonable number of seconds for a code-exec to run, in seconds
+DURATION_UNREASONABLE = 15.0
+# We'll try to sleep for well beyond that amount, for unambiguous testing
+DURATION_ATTEMPT = DURATION_UNREASONABLE * 2
+
+
+def test_deny_long_running_code():
+    """
+    Don't allow an implausibly long-running execution.
+    """
+    start = time.monotonic()
+    (_, emsg) = call_api_code_error(dedent(f"""
+      import time
+      time.sleep({DURATION_ATTEMPT!r})
+    """), {})
+    elapsed = time.monotonic() - start
+
+    # Killed by SIG_KILL == -9 (or $? == 137 in shell)
+    #
+    # This status code is important because it indicates that SIG_KILL was used
+    # by default, with no attempt at SIG_TERM or other "gentle" mechanism first.
+    assert emsg == "Couldn't execute jailed code: stdout: b'', stderr: b'' with status code: -9"
+
+    # We don't know what the actual configured proc limits are for this
+    # deployment of codejail-service, so the best bound we can set for
+    # assertions here is "we tried to sleep for much longer than X, and actually
+    # slept for less than X", where X is chosen to be higher than expected for
+    # any reasonable CPU or wall-clock limit.
+    assert elapsed < DURATION_UNREASONABLE
+
+
+def test_deny_prevent_kill():
+    """
+    Allowed to capture and ignore various signals, but it won't prevent kill.
+    """
+    start = time.monotonic()
+    (_, emsg) = call_api_code_error(dedent(f"""
+      import signal, time
+
+      def ignore(_signum, _frame):
+          pass
+
+      # Catch and ignore the relevant signals we are able to (unlike SIGKILL)
+      signal.signal(signal.SIGINT, ignore)
+      signal.signal(signal.SIGTERM, ignore)
+
+      time.sleep({DURATION_ATTEMPT!r})
+    """), {})
+    elapsed = time.monotonic() - start
+
+    # Again, this shows SIG_KILL was used.
+    assert emsg == "Couldn't execute jailed code: stdout: b'', stderr: b'' with status code: -9"
+    # Same logic as other test
+    assert elapsed < DURATION_UNREASONABLE

--- a/api_tests/utils.py
+++ b/api_tests/utils.py
@@ -1,0 +1,96 @@
+"""
+Shared utils for API tests.
+"""
+
+import functools
+import json
+import os
+
+import pytest
+import requests
+
+
+@functools.lru_cache
+def get_exec_url():
+    """
+    Get the code-exec URL.
+    """
+    base_url = os.getenv("API_TEST_SERVICE_BASE")
+    if base_url is None:
+        raise Exception("API_TEST_SERVICE_BASE environment variable missing; see api_tests/README.rst.")
+    return f"{base_url}/api/v0/code-exec"
+
+
+def call_api(code, globals_dict):
+    """
+    Call the code-exec API.
+
+    Returns a requests.Response object.
+    """
+    url = get_exec_url()
+    payload = json.dumps({
+        "code": code,
+        "globals_dict": globals_dict,
+    })
+    return requests.post(url, data={"payload": payload}, timeout=50.0)
+
+
+def get_success_globals(resp):
+    """
+    Assert that this response object was a success, and return the globals_dict.
+
+    This is both an assertion and a response parser.
+    """
+    if resp.status_code != 200:
+        pytest.fail(f"Expected response code 200, but was {resp.status_code}")
+
+    ct = resp.headers.get('content-type')
+    if ct != 'application/json':
+        pytest.fail(f"Expected JSON content type, but was {ct}")
+    json_out = resp.json()
+
+    if 'globals_dict' not in json_out:
+        pytest.fail(f"globals_dict missing from output: {json_out}")
+    if 'emsg' in json_out:
+        pytest.fail(f"Unexpected error message (emsg): {json_out['emsg']!r}")
+
+    return json_out['globals_dict']
+
+
+def get_code_error(resp):
+    """
+    Assert error message (emsg) in response and return a tuple of (globals_dict, emsg).
+
+    This is for errors arising from code execution, rather than from
+    generic client or server errors.
+
+    This is both an assertion and a response parser.
+    """
+    if resp.status_code != 200:
+        pytest.fail(f"Expected response code 200, but was {resp.status_code}")
+
+    ct = resp.headers.get('content-type')
+    if ct != 'application/json':
+        pytest.fail(f"Expected JSON content type, but was {ct}")
+    json_out = resp.json()
+
+    if 'globals_dict' not in json_out:
+        pytest.fail(f"globals_dict missing from output: {json_out}")
+    if 'emsg' not in json_out:
+        pytest.fail(f"emsg missing from output: {json_out}")
+
+    return (json_out['globals_dict'], json_out['emsg'])
+
+
+def call_api_success(*args, **kwargs):
+    """
+    Call `call_api` and `get_success_globals`, chained.
+    """
+    return get_success_globals(call_api(*args, **kwargs))
+
+
+def call_api_code_error(*args, **kwargs):
+    """
+    Call `call_api` and `get_code_error`, chained.
+    """
+    return get_code_error(call_api(*args, **kwargs))

--- a/codejail_service/__init__.py
+++ b/codejail_service/__init__.py
@@ -1,4 +1,4 @@
 """
 codejail-service module.
 """
-__version__ = '0.4.1'
+__version__ = '0.4.2'

--- a/codejail_service/apps/api/v0/tests/test_views.py
+++ b/codejail_service/apps/api/v0/tests/test_views.py
@@ -34,6 +34,22 @@ class TestExecService(TestCase):
     def tearDown(self):
         startup_check.STARTUP_SAFETY_CHECK_OK = None
 
+    def test_missing_payload(self):
+        """Handle missing payload param gracefully."""
+        client = APIClient()
+        resp = client.post('/api/v0/code-exec', {}, format='multipart')
+        assert resp.status_code == 400
+        assert json.loads(resp.content) == {'error': "Missing 'payload' parameter in POST body"}
+
+    def test_malformed_payload(self):
+        """Handle malformed payload param gracefully."""
+        client = APIClient()
+        resp = client.post('/api/v0/code-exec', {'payload': "Not JSON"}, format='multipart')
+        assert resp.status_code == 400
+        assert json.loads(resp.content) == {
+            'error': "Unable to parse payload JSON: Expecting value: line 1 column 1 (char 0)",
+        }
+
     def _test_codejail_api(self, *, params=None, files=None, exp_status, exp_body):
         """
         Call the view and make assertions.

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,8 @@ match-dir = (?!migrations)
 [pytest]
 DJANGO_SETTINGS_MODULE = codejail_service.settings.test
 addopts = --cov codejail_service --cov-report term-missing --cov-report xml
-norecursedirs = .* docs requirements site-packages
+# api_tests can be run separately, but will not be a part of unit tests.
+norecursedirs = api_tests .* docs requirements site-packages
 
 # Filter depr warnings coming from packages that we can't control.
 filterwarnings =
@@ -80,8 +81,8 @@ allowlist_externals =
 deps =
     -r{toxinidir}/requirements/quality.txt
 commands =
-    pylint codejail_service test_utils manage.py
-    pycodestyle codejail_service manage.py
-    pydocstyle codejail_service manage.py
-    isort --check-only --diff test_utils codejail_service manage.py
+    pylint codejail_service test_utils manage.py api_tests
+    pycodestyle codejail_service manage.py api_tests
+    pydocstyle codejail_service manage.py api_tests
+    isort --check-only --diff test_utils codejail_service manage.py api_tests
     make selfcheck


### PR DESCRIPTION
This adds API tests for functionality and security. It is not yet a full suite but provides a basis for further work. (See https://github.com/edx/edx-arch-experiments/issues/896).

Currently most of these pass. Two tests fail:

- `api_tests/test_filesystem.py::test_allow_write_in_own_sandbox` fails unless `CODE_JAIL['limits']['FSIZE']` is set to a non-zero value
- `api_tests/test_sandbox_deps.py::test_support_numpy` fails with a segfault, even when apparmor confinement is removed. (numpy is just unhappy with something in the docker image)

There are also two commits to add better error handling (issues uncovered during testing).

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
