### PR TITLE
test: Add additional API tests; document limitations

### DIFF
--- a/api_tests/README.rst
+++ b/api_tests/README.rst
@@ -42,7 +42,7 @@ Some aspects of the sandbox can't be readily tested in an automated fashion, or 
 
 * The sandboxed code should not have access to the environment variables that are set in the webapp's environment; these may contain sensitive information. The ``sudo`` call that codejail makes should have a side effect of creating a new environment mapping.  However, it's not clear exactly what we should look for if we wanted to test this properly.
 
-  * Testing for an exact set of env var names would lead to flaky tests, while checking for a known variable from the webapp's environment would rely too much on deployment implementation details. We can check for a few likely values, but there's nothing certain.
+  * The tests check for a few likely env vars, but it is not certain that they have been set, so the test might provide a false negative.
   * The API tests will check for the presence of ``CJS_TEST_ENV_LEAKAGE``, an optional variable that can be used for testing. Deployers are encouraged to set ``export CJS_TEST_ENV_LEAKAGE=yes`` in their webapp's environment so that this test can reliably detect leakage.
 
 * Process limits are configurable, and these tests aren't aware of what configuration has been performed in the deployment. It's difficult to write tests that will pass for all working deployments.

--- a/api_tests/README.rst
+++ b/api_tests/README.rst
@@ -34,3 +34,20 @@ To perform this sabotage testing in a development environment:
    * denial tests that are still passing (which should not happen, and likely indicates a badly written test)
    * allow/support tests that are now failing for some reason (which would be strange, and should be investigated)
    * tests that do not follow the naming scheme
+
+Limitations
+***********
+
+Some aspects of the sandbox can't be readily tested in an automated fashion, or can't be tested thoroughly.
+
+* The sandboxed code should not have access to the environment variables that are set in the webapp's environment; these may contain sensitive information. The ``sudo`` call that codejail makes should have a side effect of creating a new environment mapping.  However, it's not clear exactly what we should look for if we wanted to test this properly.
+
+  * Testing for an exact set of env var names would lead to flaky tests, while checking for a known variable from the webapp's environment would rely too much on deployment implementation details. We can check for a few likely values, but there's nothing certain.
+  * Deployers could augment the existing API tests by setting a harmless, unique environment variable in the webapp's environment e.g. ``export CJD_TEST_ENV_LEAKAGE=yes`` and then test for its presence by submitting the code ``import os; found = os.getenv('CJD_TEST_ENV_LEAKAGE')``
+
+* Process limits are configurable, and these tests aren't aware of what configuration has been performed in the deployment. It's difficult to write tests that will pass for all working deployments.
+
+  * Tests have been added for excessive runtime, memory allocation, file size, and process forking. The tests use truly excessive inputs (e.g. 1 GB of memory) to ensure that any general-purpose deployment's reasonable limits are passed. Deployments that have occasion to allow more extreme resource use may need to adjust these tests.
+  * CPU time is not tested, as it can't meaningfully be tested independently of wall clock time (at least without knowing in advance the forking limit).
+  * Only single-file size limit is tested, as codejail's process-limit mechanism cannot limit totalled filesystem writes.
+  * Deployers could augment the existing API tests using knowledge of their own configured limits. However, the codejail library has unit tests for process limits, and it may be better to rely on those tests to ensure that the configuration mechanism works properly. (Process limits are configured in-process, and are therefore less fragile and less in need of API tests than the AppArmor-based confinement mechanism.)

--- a/api_tests/README.rst
+++ b/api_tests/README.rst
@@ -43,7 +43,7 @@ Some aspects of the sandbox can't be readily tested in an automated fashion, or 
 * The sandboxed code should not have access to the environment variables that are set in the webapp's environment; these may contain sensitive information. The ``sudo`` call that codejail makes should have a side effect of creating a new environment mapping.  However, it's not clear exactly what we should look for if we wanted to test this properly.
 
   * Testing for an exact set of env var names would lead to flaky tests, while checking for a known variable from the webapp's environment would rely too much on deployment implementation details. We can check for a few likely values, but there's nothing certain.
-  * Deployers could augment the existing API tests by setting a harmless, unique environment variable in the webapp's environment e.g. ``export CJD_TEST_ENV_LEAKAGE=yes`` and then test for its presence by submitting the code ``import os; found = os.getenv('CJD_TEST_ENV_LEAKAGE')``
+  * The API tests will check for the presence of ``CJS_TEST_ENV_LEAKAGE``, an optional variable that can be used for testing. Deployers are encouraged to set ``export CJS_TEST_ENV_LEAKAGE=yes`` in their webapp's environment so that this test can reliably detect leakage.
 
 * Process limits are configurable, and these tests aren't aware of what configuration has been performed in the deployment. It's difficult to write tests that will pass for all working deployments.
 

--- a/api_tests/test_environment.py
+++ b/api_tests/test_environment.py
@@ -1,0 +1,27 @@
+"""
+Check for environment leakage.
+"""
+
+from api_tests.utils import call_api_success
+
+
+def test_deny_environment_leakage():
+    """
+    Test for environment variables that indicate an inadvertant leakage of the
+    webapp's environment into the sandbox.
+
+    We don't actually have any way of comprehensively checking the sandbox
+    environment, nor a guaranteed way of discovering a leak. But we can check
+    for a few variables that are very *plausibly* in the webapp environment.
+    """
+    globals_out = call_api_success("import os; out = {**os.environ}", {})
+    found_env = globals_out['out']
+
+    # Check that we actually did *get* the environment mapping
+    assert 'PATH' in found_env
+
+    # Commonly set in a Dockerfile during package installation, and
+    # therefore present in the webapp's environment.
+    assert "DEBIAN_FRONTEND" not in found_env
+    # If deployed service is Django-based, this might be present.
+    assert "DJANGO_SETTINGS_MODULE" not in found_env

--- a/api_tests/test_environment.py
+++ b/api_tests/test_environment.py
@@ -25,3 +25,6 @@ def test_deny_environment_leakage():
     assert "DEBIAN_FRONTEND" not in found_env
     # If deployed service is Django-based, this might be present.
     assert "DJANGO_SETTINGS_MODULE" not in found_env
+    # We document this as a variable that deployers can set in their environment
+    # to make this test reliable.
+    assert "CJS_TEST_ENV_LEAKAGE" not in found_env

--- a/api_tests/test_functional.py
+++ b/api_tests/test_functional.py
@@ -2,16 +2,23 @@
 Tests of basic functionality (just running generic Python).
 """
 
+import re
 from textwrap import dedent
 
-from api_tests.utils import call_api_success
+from api_tests.utils import call_api_code_error, call_api_success
 
 
 def test_support_globals_input_output():
     """
     We can use globals to pass inputs to the code and receive output.
     """
-    assert {"input": 21, "out": 42} == call_api_success("out = input * 2", {"input": 21})
+    globals_out = call_api_success(dedent("""
+      # Top-level mutation of global bindings
+      out = input * 2
+      # Interior mutation of globals
+      container.append(4)
+    """), {"input": 21, "container": [1, 2, 3]})
+    assert globals_out == {"input": 21, "out": 42, "container": [1, 2, 3, 4]}
 
 
 def test_support_define_function():
@@ -32,3 +39,51 @@ def test_support_selective_serialization():
     Only serializable globals are returned; others are simply omitted.
     """
     assert {"out2": "hi"} == call_api_success("out1 = object(); out2 = 'hi'", {})
+
+
+def test_support_exception_traceback_stderr():
+    """
+    Exceptions from submitted code are serialized and returned, along with stderr.
+
+    Globals aren't updated when there's an exception, even via mutation.
+    """
+    (globals_out, emsg) = call_api_code_error(dedent("""
+      # Try updating some globals (won't work)
+      primitive = 22
+      container.append(123)
+
+      # stdout is suppressed by default (due to implementation detail -- codejail
+      # delivers globals updates on stdout as JSON)
+      print("some output to stdout --- suppressed")
+
+      # stderr will be returned, though
+      import sys
+      print("other output to stderr", file=sys.stderr)
+
+      # Raise an exception
+      1/0
+    """), {"primitive": 7, "container": []})
+
+    # The codejail library isn't actually able to provide updated globals when
+    # there's an exception. If we want change that behavior, this test will need
+    # to change too.
+    #
+    # This isn't a behavior we specifically want to *preserve*; this part of the
+    # test just illustrates the effect.
+    assert globals_out == {"primitive": 7, "container": []}
+    # The emsg contains the stdout, stderr, and status code. In practice, the
+    # stdout is going to be suppressed unless the submitted code specifically
+    # works around the suppression (which is just there to prevent inadvertent
+    # failures, not for security purposes). stderr is going to have the error
+    # message embedded as part of a traceback printed to stderr.
+    #
+    # Here, we're converting line numbers to constants in order to make
+    # string comparisons work.
+    emsg_comparable = re.sub(r' line [0-9]+', ' line NN', emsg)
+    assert emsg_comparable == (
+        "Couldn't execute jailed code: stdout: b'', "
+        r"stderr: b'other output to stderr\nTraceback (most recent call last):\n"
+        r'  File "jailed_code", line NN, in <module>\n    exec(code, g_dict)\n'
+        r'  File "<string>", line NN, in <module>\n'
+        r"ZeroDivisionError: division by zero\n' with status code: 1"
+    )

--- a/api_tests/test_functional.py
+++ b/api_tests/test_functional.py
@@ -48,7 +48,7 @@ def test_support_exception_traceback_stderr():
     Globals aren't updated when there's an exception, even via mutation.
     """
     (globals_out, emsg) = call_api_code_error(dedent("""
-      # Try updating some globals (won't work)
+      # Try updating some globals (won't show up in output globals, though)
       primitive = 22
       container.append(123)
 
@@ -65,7 +65,7 @@ def test_support_exception_traceback_stderr():
     """), {"primitive": 7, "container": []})
 
     # The codejail library isn't actually able to provide updated globals when
-    # there's an exception. If we want change that behavior, this test will need
+    # there's an exception. If we want to change that behavior, this test will need
     # to change too.
     #
     # This isn't a behavior we specifically want to *preserve*; this part of the

--- a/api_tests/test_memory.py
+++ b/api_tests/test_memory.py
@@ -1,0 +1,23 @@
+"""
+Tests for memory allocation.
+"""
+
+from textwrap import dedent
+
+from api_tests.utils import call_api_code_error
+
+
+def test_deny_large_allocate():
+    """
+    Can't allocate large amounts of memory.
+    """
+    # Try to allocate 1 GiB. This is a reasonable amount to allocate on a normal
+    # system, but an unreasonable amount within a sandbox. (We don't know what
+    # limit has actually been configured in the deployment.)
+    code = dedent("""
+      # Spread the allocation across a number of more reasonably sized objects
+      arr = [bytearray(1024 * 32) for _ in range(32 * 1024)]
+      out = len(arr)
+    """)
+    (_, emsg) = call_api_code_error(code, {})
+    assert "MemoryError" in emsg

--- a/api_tests/test_network.py
+++ b/api_tests/test_network.py
@@ -53,9 +53,14 @@ class TestSocketCreate(TestCase):
         """
         Can't create a socket (even without calling bind or connect).
 
-        If we *could* create sockets, the next step would be checking which
-        destinations we can bind or connect to. In particular, we'd want to
-        check each of public, network-internal, and loopback addresses.
+        If we later decide to allow *creating* sockets (for some reason), or the
+        confinement mechanism allows creating sockets and only steps in to deny
+        at the bind/connect phase, the next step would be to enhance these tests
+        to check which addresses we can bind and which destinations we can connect to.
+
+        In particular, we'd want to check addresses in each of the public,
+        network-internal, and loopback address segments, and both IPv4 and IPv6, for
+        both bind and connect.
         """
         code = dedent(f"""
           import socket

--- a/api_tests/test_network.py
+++ b/api_tests/test_network.py
@@ -52,6 +52,10 @@ class TestSocketCreate(TestCase):
     def test_deny_create_socket(self, address_family, socket_type):
         """
         Can't create a socket (even without calling bind or connect).
+
+        If we *could* create sockets, the next step would be checking which
+        destinations we can bind or connect to. In particular, we'd want to
+        check each of public, network-internal, and loopback addresses.
         """
         code = dedent(f"""
           import socket

--- a/api_tests/test_process.py
+++ b/api_tests/test_process.py
@@ -3,11 +3,14 @@ Tests for process creation.
 """
 
 from textwrap import dedent
+from unittest import TestCase
+
+import ddt
 
 from api_tests.utils import call_api_code_error
 
 
-def test_deny_fork():
+def test_deny_fork_excessively():
     """
     Can't fork own process excessively.
     """
@@ -28,3 +31,34 @@ def test_deny_fork():
     """), {})
     # 11 = EAGAIN: Resource temporarily unavailable (process limit, in this case)
     assert "BlockingIOError: [Errno 11] Resource temporarily unavailable" in emsg
+
+
+@ddt.ddt
+class TestExecProcess(TestCase):
+    """
+    Tests for exec'ing new processes (not forking).
+    """
+
+    @ddt.data(
+        # Some harmless binary that will definitely exist and that would quickly exit 0
+        repr("/usr/bin/true"),
+        # Similar test, although we're assuming there's permission to list working dir
+        repr("/usr/bin/ls"),
+        # Evaluates to the Python executable the sandboxed code is running under
+        "sys.executable",
+        # Python 3.8, on the PATH
+        repr("python3.8"),
+    )
+    def test_deny_subprocess(self, bin_path_expr):
+        """
+        Despite allowing multiple processes, we can't actually exec new ones.
+
+        bin_path_expr: A Python expression code that evaluates (in sandbox) to a
+          string, naming the path to a binary we will try to execute.
+        """
+        code = dedent(f"""
+          import subprocess, sys
+          subprocess.run({bin_path_expr})
+        """)
+        (_, emsg) = call_api_code_error(code, {})
+        assert "Permission denied" in emsg

--- a/api_tests/test_process_table.py
+++ b/api_tests/test_process_table.py
@@ -1,0 +1,25 @@
+"""
+Tests of attempts to access the process table.
+
+These should all be denied. Accessing the process table could reveal the
+directory in use for another active code execution, and we don't have any
+protection against that other than unpredictable directory names.
+"""
+
+from api_tests.utils import call_api_code_error
+
+
+def test_deny_list_proc():
+    """
+    Not allowed to list processes via /proc pseudo-filesystem.
+    """
+    (_, emsg) = call_api_code_error("import os; out = os.listdir('/proc')", {})
+    assert "Permission denied" in emsg
+
+
+def test_deny_exec_ps():
+    """
+    Disallow execution of `ps` to reveal processes.
+    """
+    (_, emsg) = call_api_code_error("import subprocess; subprocess.run('ps')", {})
+    assert "Permission denied" in emsg

--- a/codejail_service/apps/api/v0/views.py
+++ b/codejail_service/apps/api/v0/views.py
@@ -143,4 +143,10 @@ def code_exec(request):
         return Response({'globals_dict': globals_out})
     else:
         log.debug("Codejail execution failed for {slug=} with: {error_message}")
+        # Nothing in edxapp actually *uses* the returned globals when there's an
+        # emsg, but it does demand that the key is present in the response. The
+        # globals also aren't updated when codejail encountered an error. We
+        # could just as well return {} here, but we returned the "updated"
+        # globals for compatibility with eduNEXT's existing implementation, just
+        # in case anything actually does care.
         return Response({'globals_dict': globals_out, 'emsg': error_message})

--- a/codejail_service/apps/api/v0/views.py
+++ b/codejail_service/apps/api/v0/views.py
@@ -146,7 +146,7 @@ def code_exec(request):
         # Nothing in edxapp actually *uses* the returned globals when there's an
         # emsg, but it does demand that the key is present in the response. The
         # globals also aren't updated when codejail encountered an error. We
-        # could just as well return {} here, but we returned the "updated"
-        # globals for compatibility with eduNEXT's existing implementation, just
-        # in case anything actually does care.
+        # could just as well return {} here, but the service returns the "updated"
+        # globals for backward-compatibility, just in case anything actually does
+        # care.
         return Response({'globals_dict': globals_out, 'emsg': error_message})


### PR DESCRIPTION
- How exceptions work
- Interior and exterior mutation of globals is captured
- Large allocations
- Process execution
- Process enumeration
- Environment leakage
- File deletion, large file creation

Also:

- Document the API test limitations
- Use a variable for the write-testing path in FS tests
- Add caveat to network test


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
