### PR TITLE
feat: Add startup check that attempts network egress

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Change Log
 Unreleased
 **********
 
-1.0.0 - 2025-03-27
+1.0.0 - 2025-03-26
 ******************
 
 This is now version 1.x to reflect the maturity of the codebase.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 **********
 
+1.0.0 - 2025-03-27
+******************
+
+This is now version 1.x to reflect the maturity of the codebase.
+
+Added
+=====
+* Add safety check that attempts an outbound network connection from the webapp (not from inside the sandbox).
+
 0.6.0 - 2025-03-17
 ******************
 Changed

--- a/codejail_service/__init__.py
+++ b/codejail_service/__init__.py
@@ -1,4 +1,4 @@
 """
 codejail-service module.
 """
-__version__ = '0.6.0'
+__version__ = '1.0.0'

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -63,6 +63,8 @@ Again following the codejail library's instructions, create an AppArmor profile 
 
 This profile will need to be customized according to your service's app user, sandbox setup, and other details. It will also look different if you are using Docker or running the service directly on the host. For reference, here is `2U's AppArmor profile <https://github.com/edx/public-dockerfiles/blob/main/apparmor/openedx_codejail_service.profile>`__; note that the inner profile is the one that actually applies the sandboxing.
 
+codejail-service also expects that outbound networking from the webapp itself will be blocked. This can be implemented in AppArmor or in container configuration (e.g. Kubernetes ``NetworkPolicy``).
+
 Django settings
 ***************
 


### PR DESCRIPTION
This is an additional precaution for possible sandbox escapes. It is not strictly necessary, and in the future we may wish to make this check optional (for deployers who have other telemetry needs, for instance).

Also:

- Rename `test_success_and_failure_modes` to `test_safe_exec_success_and_failure_modes` to include "safe_exec" in the name, highlighting the distinction from the new egress test.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
