### PR TITLE
test: Better API test for NPROC

### DIFF
--- a/api_tests/test_process.py
+++ b/api_tests/test_process.py
@@ -67,7 +67,7 @@ def test_deny_fork_excessively():
       # If goal is 1, the current process fulfills the goal.
       while goal > 1:
           # Split goal into roughly equal integer halves.
-          #Each will be >= 1 if goal > 1.
+          # Each will be >= 1 if goal > 1.
           goal_parent = goal // 2
           goal_child = goal - goal_parent
 


### PR DESCRIPTION
The previous version forked linearly, which seems to be the cause of some problems we haven't yet entirely characterized. This version uses a (capped) forkbomb to reach the full count of processes very quickly, and also prunes the tree to produce an exact number of processes.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
