### PR TITLE
feat: Add logging for several client error situations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ Changelog
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
 
+2025-04-18
+**********
+Added
+=====
+* Add logging for several client error situations
+* Add custom attribute for slug
+
 2025-04-04
 **********
 Added


### PR DESCRIPTION
The additional logging should help us debug https://github.com/edx/edx-arch-experiments/issues/1028 in which there's a schema error. Include path to error in schema errors as well.

The other changes are for other errors we might observe in the future:

- Log unexpected filenames
- Log unexpected python_path values
- Log JSON errors
- Add custom attribute for slug

Also, expand a couple tests with additional cases.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
