### PR TITLE
fix: Allow returning float specials

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,13 @@ Changelog
 
 2025-04-18
 **********
+Fixed
+=====
+* Allow float specials like NaN and Infinity in globals_dict. (Was causing HTTP
+  error due to JSON de/serialization.)
+
+2025-04-18
+**********
 Added
 =====
 * Add logging for several client error situations

--- a/codejail_service/apps/api/v0/views.py
+++ b/codejail_service/apps/api/v0/views.py
@@ -91,6 +91,12 @@ def code_exec(request):
     (an error message string) if the submitted code raised an exception.
 
     Other responses are errors, with a JSON body containing further details.
+
+    Special note: The JSON format used by this endpoint permits floating point
+    special values such as `NaN` and `Infinity`, which standards-compliant JSON
+    implementations will not accept or produce. Python's `json` module allows
+    them by default, but other implementations may need to be configured
+    specially.
     """
     if not CODEJAIL_ENABLED.is_enabled():
         # .. custom_attribute_name: codejail.exec.status

--- a/codejail_service/settings/base.py
+++ b/codejail_service/settings/base.py
@@ -38,6 +38,16 @@ MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
 )
 
+REST_FRAMEWORK = {
+    # We need to accept and return special floats like NaN and Infinity in
+    # globals_dict, despite these not being legal JSON according to the
+    # RFC. Python's json module allows these by default, so we don't get errors
+    # at the safe_exec JSON de/serialization level, but we also need to
+    # de/serialize across the network. That's up to DRF, which uses a strict
+    # mode by default. We need to turn that off.
+    'STRICT_JSON': False,
+}
+
 ROOT_URLCONF = 'codejail_service.urls'
 
 # Python dotted path to the WSGI application used by Django's runserver.


### PR DESCRIPTION
Issue observed during dark launch.

Addresses https://github.com/openedx/codejail-service/issues/47


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
