### PR TITLE
test: Send a slug with API test calls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ Changelog
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
 
+2025-04-25
+**********
+Added
+=====
+* Send a slug with API test calls to help distinguish them from normal traffic.
+
 2025-04-18
 **********
 Fixed

--- a/api_tests/utils.py
+++ b/api_tests/utils.py
@@ -11,7 +11,7 @@ import requests
 
 
 @functools.lru_cache
-def get_exec_url():
+def _get_exec_url():
     """
     Get the code-exec URL.
     """
@@ -33,11 +33,15 @@ def call_api(code, globals_dict, /, *, files=None, python_path=None):
 
     Returns a requests.Response object.
     """
-    url = get_exec_url()
+    url = _get_exec_url()
     payload = json.dumps({
         "code": code,
         "globals_dict": globals_dict,
         "python_path": python_path,
+        # Help operators detect that weird/broken calls they're seeing in
+        # codejail-service might actually be from the API tests, not a broken
+        # client.
+        "slug": "codejail-service-api-tests",
     })
     return requests.post(url, data={"payload": payload}, files=files, timeout=50.0)
 


### PR DESCRIPTION
This will help distinguish them from normal traffic.

Also, rename `get_exec_url` with leading underscore to ensure that all API tests are going through `call_api` (which adds the slug).


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
