### PR TITLE
test: Make API tests compatible with Python 3.11 and 3.12

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,13 @@ Changelog
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
 
-2025-04-18
+2025-04-28
+**********
+Fixed
+=====
+* Make API tests compatible with Python 3.11 and 3.12
+
+2025-04-22
 **********
 Fixed
 =====

--- a/api_tests/test_functional.py
+++ b/api_tests/test_functional.py
@@ -80,10 +80,18 @@ def test_support_exception_traceback_stderr():
     # Here, we're converting line numbers to constants in order to make
     # string comparisons work.
     emsg_comparable = re.sub(r' line [0-9]+', ' line NN', emsg)
+    # We also need to account for differences in how Python 3.8 and 3.11 print
+    # relative file names in stack traces. Some time after 3.8, they start being
+    # turned into absolute paths.
+    emsg_comparable = re.sub(
+        r'File "(/tmp/codejail-[0-9a-z]+/)?jailed_code"',
+        r'File "<JAILED_CODE_PATH>"',
+        emsg_comparable
+    )
     assert emsg_comparable == (
         "Couldn't execute jailed code: stdout: b'', "
         r"stderr: b'other output to stderr\nTraceback (most recent call last):\n"
-        r'  File "jailed_code", line NN, in <module>\n    exec(code, g_dict)\n'
+        r'  File "<JAILED_CODE_PATH>", line NN, in <module>\n    exec(code, g_dict)\n'
         r'  File "<string>", line NN, in <module>\n'
         r"ZeroDivisionError: division by zero\n' with status code: 1"
     )

--- a/api_tests/test_process.py
+++ b/api_tests/test_process.py
@@ -57,8 +57,9 @@ class TestExecProcess(TestCase):
         repr("/usr/bin/ls"),
         # Evaluates to the Python executable the sandboxed code is running under
         "sys.executable",
-        # Python 3.8, on the PATH
-        repr("python3.8"),
+        # Python, on the PATH. (Use 3 rather than 3.11, etc. to make this
+        # compatible with range of versions.)
+        repr("python3"),
     )
     def test_deny_subprocess(self, bin_path_expr):
         """


### PR DESCRIPTION
Also, fix previous date in changelog.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
