### PR TITLE
test: Fix character range for tmpdir normalization

### DIFF
--- a/api_tests/test_functional.py
+++ b/api_tests/test_functional.py
@@ -84,7 +84,7 @@ def test_support_exception_traceback_stderr():
     # relative file names in stack traces. Some time after 3.8, they start being
     # turned into absolute paths.
     emsg_comparable = re.sub(
-        r'File "(/tmp/codejail-[0-9a-z]+/)?jailed_code"',
+        r'File "(/tmp/codejail-[0-9a-zA-Z_]+/)?jailed_code"',
         r'File "<JAILED_CODE_PATH>"',
         emsg_comparable
     )


### PR DESCRIPTION
Python's tempfile naming also includes underscore: https://github.com/python/cpython/blob/3.12/Lib/tempfile.py#L140

This omission was causing tests to fail about 1/6 of the time.

Also include uppercase letters in regex even though Python sticks to lowercase (just for good measure).


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
