### PR TITLE
feat: Allow overriding logging format string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ Changelog
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
 
+2025-05-20
+**********
+Added
+=====
+* New Django setting ``LOGGING_FORMAT_STRING`` allows overriding the standard logger's format string.
+
 2025-04-28
 **********
 Added

--- a/codejail_service/settings/base.py
+++ b/codejail_service/settings/base.py
@@ -72,5 +72,8 @@ LOCALE_PATHS = (
     root('conf', 'locale'),
 )
 
+# Allow overriding the default logging format string.
+LOGGING_FORMAT_STRING = None
+
 # Set up logging for development use (logging to stdout)
-LOGGING = get_logger_config(debug=DEBUG)
+LOGGING = get_logger_config(debug=DEBUG, format_string=LOGGING_FORMAT_STRING)

--- a/codejail_service/settings/production.py
+++ b/codejail_service/settings/production.py
@@ -10,8 +10,6 @@ from codejail_service.settings.utils import get_env_setting
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
-LOGGING = get_logger_config()
-
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
 DICT_UPDATE_KEYS = ()
@@ -30,3 +28,6 @@ if 'CODEJAIL_SERVICE_CFG' in environ:
                 vars()[key].update(value)
 
         vars().update(config_from_yaml)
+
+# Below YAML loading so that LOGGING_FORMAT_STRING can be set
+LOGGING = get_logger_config(format_string=LOGGING_FORMAT_STRING)

--- a/codejail_service/settings/utils.py
+++ b/codejail_service/settings/utils.py
@@ -17,14 +17,22 @@ def get_env_setting(setting):
 
 
 def get_logger_config(
-    logging_env="no_env",
-    debug=False,
-    service_variant='codejail-service',
+    logging_env: str = "no_env",
+    debug: bool = False,
+    service_variant: str = 'codejail-service',
+    format_string: str = None,
 ):
     """
-    Return the appropriate logging config dictionary.
+    Return the appropriate logging config dictionary, to be assigned to the LOGGING var in settings.
 
-    You should assign the result of this to the LOGGING var in your settings.
+    Arguments:
+        logging_env (str): Environment name.
+        debug (bool): Debug logging enabled.
+        service_variant (str): Name of the service.
+        format_string (str): Override format string for your logfiles.
+
+    Returns:
+        dict(string): Returns a dictionary of config values
     """
     hostname = platform.node().split(".")[0]
     syslog_format = (
@@ -39,13 +47,17 @@ def get_logger_config(
 
     handlers = ['console']
 
+    standard_format = format_string or (
+        '%(asctime)s %(levelname)s %(process)d '
+        '[%(name)s] [user %(userid)s] [ip %(remoteip)s] %(filename)s:%(lineno)d - %(message)s'
+    )
+
     logger_config = {
         'version': 1,
         'disable_existing_loggers': False,
         'formatters': {
             'standard': {
-                'format': '%(asctime)s %(levelname)s %(process)d '
-                          '[%(name)s] [user %(userid)s] [ip %(remoteip)s] %(filename)s:%(lineno)d - %(message)s',
+                'format': standard_format,
             },
             'syslog_format': {'format': syslog_format},
             'raw': {'format': '%(message)s'},


### PR DESCRIPTION
Copying same pattern from some other services, although not including the ability to read setting from environment.

This will allow us to inject trace correlation information into the logs.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
