### PR TITLE
feat: Upgrade to codejail 4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ Changelog
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
 
+2025-06-16
+**********
+Changed
+=======
+* Upgrade to codejail 4.0.0, which no longer defaults to running in unsafe mode. This should make it a little harder for codejail-service to be misconfigured by accident.
+
 2025-05-20
 **********
 Added

--- a/codejail_service/codejail.py
+++ b/codejail_service/codejail.py
@@ -6,6 +6,8 @@ import logging
 from copy import deepcopy
 from json.decoder import JSONDecodeError
 
+from codejail.safe_exec import SafeExecException
+from codejail.safe_exec import safe_exec as real_safe_exec
 from edx_django_utils.monitoring import record_exception
 
 log = logging.getLogger(__name__)
@@ -27,17 +29,6 @@ def safe_exec(code, input_globals, **kwargs):
     an error is raised, without requiring us to mutate the input. (And this
     approach is much better for unit testing than the mutation option is.)
     """
-    # This needs to be a lazy import because as soon as codejail's
-    # safe_exec module loads, it immediately makes a decision about
-    # whether to run in always-unsafe mode.
-    #
-    # See https://github.com/openedx/codejail/issues/16 for maybe
-    # fixing this.
-
-    # pylint: disable=import-outside-toplevel
-    from codejail.safe_exec import SafeExecException
-    from codejail.safe_exec import safe_exec as real_safe_exec
-
     # Prevent mutation of input
     output_globals = deepcopy(input_globals)
     try:

--- a/docs/decisions/0001-purpose-of-this-repo.rst
+++ b/docs/decisions/0001-purpose-of-this-repo.rst
@@ -27,6 +27,11 @@ In 2021 eduNEXT had previously implemented a Flask-based remote codejail service
 
 In 2025, 2U made a push to move its own deployment of edx-platform from the legacy Ansible and EC2 based build system to a Docker and Kubernetes system. In the process, 2U wanted to move to a remote codejail for both security and ease of deployment reasons.
 
+Updates
+=======
+
+- 2025-06-16: As of codejail 4.0.0, it is no longer true that the library defaults to running without any attempt at confinement. (However, it still has no way of protecting against missing or misconfigured AppArmor.)
+
 Decision
 ********
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,6 +5,7 @@ Django                   # Web application framework
 gunicorn                 # HTTP server framework
 edx-django-utils         # Monitoring utilities, among other things
 edx-toggles              # Feature switch tools
-edx-codejail             # Actual codejail library
+# Codejail 3 and below will automatically run in unsafe mode if unconfigured.
+edx-codejail>=4.0.0      # Actual codejail library
 djangorestframework      # Request parsing and response formatting
 jsonschema               # Parse and validate JSON

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,7 @@ django-waffle==4.2.0
     #   edx-toggles
 djangorestframework==3.16.0
     # via -r requirements/base.in
-edx-codejail==3.5.2
+edx-codejail==4.0.0
     # via -r requirements/base.in
 edx-django-utils==8.0.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -110,7 +110,7 @@ docutils==0.21.2
     # via
     #   -r requirements/validation.txt
     #   readme-renderer
-edx-codejail==3.5.2
+edx-codejail==4.0.0
     # via -r requirements/validation.txt
 edx-django-utils==8.0.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -107,7 +107,7 @@ docutils==0.21.2
     #   pydata-sphinx-theme
     #   restructuredtext-lint
     #   sphinx
-edx-codejail==3.5.2
+edx-codejail==4.0.0
     # via -r requirements/test.txt
 edx-django-utils==8.0.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -94,7 +94,7 @@ djangorestframework==3.16.0
     # via -r requirements/test.txt
 docutils==0.21.2
     # via readme-renderer
-edx-codejail==3.5.2
+edx-codejail==4.0.0
     # via -r requirements/test.txt
 edx-django-utils==8.0.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -72,7 +72,7 @@ django-waffle==4.2.0
     #   edx-toggles
 djangorestframework==3.16.0
     # via -r requirements/base.txt
-edx-codejail==3.5.2
+edx-codejail==4.0.0
     # via -r requirements/base.txt
 edx-django-utils==8.0.0
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -121,7 +121,7 @@ docutils==0.21.2
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-edx-codejail==3.5.2
+edx-codejail==4.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
This brings an important security improvement (although codejail-service has other protections against misconfigured codejail.)

It is now also safe to import `codejail.safe_exec` at any time, rather than having to delay it until after configuration has happened. Our safe_exec wrapper can now be simplified a bit as a result.

Also, add missing `super.tearDown()` in a test class.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
